### PR TITLE
For FreeBSD

### DIFF
--- a/lib/em/filetail.rb
+++ b/lib/em/filetail.rb
@@ -154,7 +154,10 @@ class EventMachine::FileTail
       @reopen_on_eof = true
       schedule_next_read
     elsif status == :unbind
-      # Do what?
+      # :unbind is called after the :deleted handler
+      # :deleted happens on FreeBSD's newsyslog instead of :moved
+      # clean up @watch since its reference is wiped in EM's file_deleted callback
+      @watch = nil
     end
   end # def notify
 


### PR DESCRIPTION
Great library, however it blew up last night during my system's log rotation scheme. 

After some debugging this morning, I discovered that when FreeBSD's newsyslog rotates files, @watch receives the :deleted callback instead of :moved.  

When the :deleted callback is run, FileWatch#stop_watching is automatically run.  After that, :unbind is naturally called.  

(see http://eventmachine.rubyforge.org/EventMachine.html under "watch_file")

If we do nothing in unbind, the call "@watch.stop_watching if @watch" will fault, as @watch's reference has already been destroyed.

So, I added code to nil out @watch when :unbind is run.
