### PR TITLE
Add ability to notify also when a file is changed.

### DIFF
--- a/samples/globwatch.rb
+++ b/samples/globwatch.rb
@@ -16,6 +16,10 @@ class Watcher < EventMachine::FileGlobWatch
   def file_found(path)
     puts "Found: #{path}"
   end
+
+  def file_modified(path)
+    puts "Modified: #{path}"
+  end
 end # class Watcher
 
 EM.run do


### PR DESCRIPTION
When a file is already in the tracked list, it is ignored. It is just two LOC away to be notified also when the file content changes.

Add separate mock class to test for notification of files' modifications.
Update FileGlobWatch to check if the mtime of the current file changed since
the last time it was checked.
Update samples to reflect new use case.
