### PR TITLE
When the input file is moved, do not set @reopen_on_eof right away.

### DIFF
--- a/lib/em/filetail.rb
+++ b/lib/em/filetail.rb
@@ -173,7 +173,6 @@ class EventMachine::FileTail
       schedule_next_read
     elsif status == :moved
       # read to EOF, then reopen.
-      @reopen_on_eof = true
       schedule_next_read
     elsif status == :unbind
       # :unbind is called after the :deleted handler


### PR DESCRIPTION
Setting @reopen_on_eof on a file move notification could result in data not being read from the input file.
Say I want to use FileTail to read a log file. Typically, a log file is rolled/rotated by:
1. Renaming it (X -> Y)
2. Closing it (and flushing any output)
3. Reopening a new file with the original name (X)
If, between steps 1 and 2, FileTail receives notification the file was moved, sets @reopen_on_eof, reads, and gets an EOF, it will miss any data that was not flushed by the process writing the file.
However, this case is handled correctly in a different part of the code. If a normal read results in an EOF, @reopen_on_eof will be set if the file exists (by name) and has a changed inode. Therefore, setting @reopen_on_eof here is unnecessary.