### PR TITLE
Fixing race condition when watching symlinks that change frequently

### DIFF
--- a/lib/em/filetail.rb
+++ b/lib/em/filetail.rb
@@ -356,18 +356,18 @@ class EventMachine::FileTail
   def read_file_metadata(&block)
     begin
       filestat = File.stat(@path)
+      symlink_stat = nil
+      symlink_target = nil
+
+      if filestat.symlink?
+        symlink_stat = File.lstat(@path) rescue nil
+        symlink_target = File.readlink(@path) rescue nil
+      end
     rescue Errno::ENOENT
       raise
     rescue => e
       @logger.debug("File stat on '#{@path}' failed")
       on_exception e
-    end
-    symlink_stat = nil
-    symlink_target = nil
-
-    if File.symlink?(@path)
-      symlink_stat = File.lstat(@path) rescue nil
-      symlink_target = File.readlink(@path) rescue nil
     end
 
     if block_given?


### PR DESCRIPTION
When watching symlinks that change frequently this code would be unable to lstat the symlink even though the stat succeeded. I tightened this lookup to happen faster after stat and I also used the symlink? check on the return from stat instead of another File call to reduce the frequency of this race condition.

Reproduction:
Watch a symlink in tmp created like this: 
```bash
touch /tmp/test_target ; ln -sf /tmp/test_target /tmp/test_link
```

Run this command to replace the symlink constantly and watch your tailer throw an exception while trying to grab the inode: 
```bash
while true; do rm -f /tmp/test_link; touch /tmp/test_target; ln -sf /tmp/test_target /tmp/test_link; done
```

You will get an exception similar to this:
```
/usr/etsy/deployinator/vendor/bundle/ruby/1.9.1/gems/eventmachine-tail-0.6.4/lib/em/filetail.rb:388:in `handle_fstat': undefined method `ino' for nil:NilClass (NoMethodError)
```